### PR TITLE
Support disable for zoom

### DIFF
--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -19,6 +19,7 @@ export interface ItemProps {
   imageMargin: number
   imageSize: number
   onClick: (item: PhotoProps) => void
+  isZoomEnabled?: boolean
   setZoomImage: React.Dispatch<
     React.SetStateAction<string | undefined>
   >
@@ -56,6 +57,7 @@ const Item = observer(
     imageMargin,
     imageSize,
     onClick,
+    isZoomEnabled,
     setZoomImage,
   }: ItemProps): JSX.Element => {
     const { localSelected } = CommonStore
@@ -74,7 +76,9 @@ const Item = observer(
           marginRight: imageMargin,
         }}
         onPress={(): void => {
-          setZoomImage(item.uri)
+          isZoomEnabled
+            ? setZoomImage(item.uri)
+            : onClick(item)
         }}
       >
         <ImageComp

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,9 @@ const PhotoSelector = (props: PhotoSelectorProps): JSX.Element => {
 
   const flatListRef = useRef<FlatList>(null)
 
-  const isZoomEnabled = zoomImageOption?.isZoomEnabled || true;
+  const isZoomEnabled = zoomImageOption?.isZoomEnabled !== undefined
+    ? zoomImageOption?.isZoomEnabled
+    : true;
   const imagesPerRow = imageListOption?.imagesPerRow
     ? imageListOption.imagesPerRow
     : 3

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,7 @@ interface ImageListProps {
 }
 
 interface ZoomImageProps {
+  isZoomEnabled?: boolean
   closeButton?: JSX.Element
   closeContainerStyle?: ViewStyle
 }
@@ -103,6 +104,7 @@ const PhotoSelector = (props: PhotoSelectorProps): JSX.Element => {
 
   const flatListRef = useRef<FlatList>(null)
 
+  const isZoomEnabled = zoomImageOption?.isZoomEnabled || true;
   const imagesPerRow = imageListOption?.imagesPerRow
     ? imageListOption.imagesPerRow
     : 3
@@ -361,6 +363,7 @@ const PhotoSelector = (props: PhotoSelectorProps): JSX.Element => {
                   selectedMarker,
                   imageSize,
                   onClick: selectImage,
+                  isZoomEnabled,
                   setZoomImage,
                 }}
               />


### PR DESCRIPTION
Users should be able to decide whether to enable/disable the zoom feature by passing the `zoomImageOption?.isZoomEnabled` prop to `true` or `false`(defaults to `true` for backward compatibility).